### PR TITLE
Fix the curve for calculating y-offset.

### DIFF
--- a/src/lightsim/WaveController.java
+++ b/src/lightsim/WaveController.java
@@ -56,8 +56,15 @@ public class WaveController extends LightController {
         double xHalfAmp = modulateValue(X_HALF_AMP_MIN, X_HALF_AMP_MAX, X_AMP_PERIOD, theta);
         double xLength = modulateValue(X_LENGTH_MIN, X_LENGTH_MAX, X_LENGTH_PERIOD, theta);
         double xWidth = modulateValue(X_WIDTH_MIN, X_WIDTH_MAX, X_WIDTH_PERIOD, theta);
-        double yOffsetPeriodMul = modulateValue(Y_OFFSET_PERIOD_MUL_MIN, Y_OFFSET_PERIOD_MUL_MAX, Y_OFFSET_PERIOD_MUL_PERIOD, theta);
-        double yOffset = modulateValue(Y_OFFSET_MIN, Y_OFFSET_MAX, yOffsetPeriodMul * Y_OFFSET_PERIOD, theta);
+
+        // For y-offset, shift between a faster (low period) and slower (high period) curve.
+        // The phase is a [0..1] value that determines which curve dominates in the final
+        // value.
+        double yOffsetPhase = modulateValue(0, 1, Y_OFFSET_PERIOD_MUL_PERIOD, theta);
+        double yOffsetSlow = Math.sin(theta * Math.PI / (Y_OFFSET_PERIOD * Y_OFFSET_PERIOD_MUL_MAX));
+        double yOffsetFast = Math.sin(theta * Math.PI / (Y_OFFSET_PERIOD * Y_OFFSET_PERIOD_MUL_MIN));
+        double yOffsetHalfAmp = (Y_OFFSET_MAX - Y_OFFSET_MIN) / 2.0;
+        double yOffset = yOffsetHalfAmp * (Y_OFFSET_MIN + (yOffsetPhase * yOffsetSlow + (1.0 - yOffsetPhase) * yOffsetFast));
         
         double colorProgTime = time / COLOR_PERIOD; 
         Color currentColor = Colors.sixColorProg(colorProgTime - Math.floor(colorProgTime));


### PR DESCRIPTION
Modulating a curve's period over time is a bad idea, because with high values for theta, very slight differences in the period cause a large change in the y-value. Instead "cross-fade" between a high-period and a low-period curve.