### PR TITLE
Fix access control for the web server.

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -110,7 +110,7 @@ class ControlPanel extends React.Component {
   }
 
   sendControlRequest(command) {
-    fetch("http://localhost:8000/control/" + command)
+    fetch("http://" + window.location.hostname + ":8000/control/" + command)
       .then(res => res.json())
       .then((result) => {
         console.log("Response from control server: " + JSON.stringify(result));

--- a/src/lightsim/Server.java
+++ b/src/lightsim/Server.java
@@ -101,8 +101,10 @@ public class Server implements HttpHandler, ExecListener {
                 break;
         }
 
+        Headers requestHeaders = exchange.getRequestHeaders();
+        String origin = requestHeaders.get("Origin").get(0);
         Headers responseHeaders = exchange.getResponseHeaders();
-        responseHeaders.add("Access-Control-Allow-Origin", "http://localhost:3000");
+        responseHeaders.add("Access-Control-Allow-Origin", origin);
 
         String response = getStatusJson();
         exchange.sendResponseHeaders(200, response.length());


### PR DESCRIPTION
- Have the Java server set Access-Control-Allow-Origin to the requester.
- Have the node server send requests to itself rather than to localhost.